### PR TITLE
Docs: Add docker compose up instruction to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Future functionality:
 ## Setup
 
 ```bash
+# Start the database (if using Docker)
+docker compose up -d
+
 # Install dependencies
 yarn
 ```


### PR DESCRIPTION
Added the `docker compose up -d` command to the "Setup" section of the README.md file. This ensures you are aware of the need to start the database services before running the application.